### PR TITLE
feat(cloudrun_pubsub): migrate to pubsub v2

### DIFF
--- a/gcp/cloudrun_pubsub/go.mod
+++ b/gcp/cloudrun_pubsub/go.mod
@@ -2,7 +2,10 @@ module github.com/fredrikaverpil/go-playground/gcp/cloudrun_pubsub
 
 go 1.26.2
 
-require cloud.google.com/go/pubsub v1.50.2
+require (
+	cloud.google.com/go/pubsub/v2 v2.4.0
+	google.golang.org/grpc v1.79.3
+)
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
@@ -10,7 +13,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
-	cloud.google.com/go/pubsub/v2 v2.4.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -19,12 +21,15 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect
 	github.com/googleapis/gax-go/v2 v2.18.0 // indirect
+	go.einride.tech/aip v0.83.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
@@ -37,6 +42,5 @@ require (
 	google.golang.org/genproto v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260311181403-84a4fc48630c // indirect
-	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/gcp/cloudrun_pubsub/go.sum
+++ b/gcp/cloudrun_pubsub/go.sum
@@ -9,12 +9,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
 cloud.google.com/go/iam v1.5.3/go.mod h1:MR3v9oLkZCTlaqljW6Eb2d3HGDGK5/bDv93jhfISFvU=
-cloud.google.com/go/kms v1.26.0 h1:cK9mN2cf+9V63D3H1f6koxTatWy39aTI/hCjz1I+adU=
-cloud.google.com/go/kms v1.26.0/go.mod h1:pHKOdFJm63hxBsiPkYtowZPltu9dW0MWvBa6IA4HM58=
-cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7EhfW8=
-cloud.google.com/go/longrunning v0.8.0/go.mod h1:UmErU2Onzi+fKDg2gR7dusz11Pe26aknR4kHmJJqIfk=
-cloud.google.com/go/pubsub v1.50.2 h1:54Up97HnThdP4H8jjWJSSQ/mnYG2EKon7ZSNETRq0tM=
-cloud.google.com/go/pubsub v1.50.2/go.mod h1:jyCWeZdGFqd4mitSsBERnJcpqaHBsxQoPkNvjj4sp0w=
 cloud.google.com/go/pubsub/v2 v2.4.0 h1:oMKNiBQpXImRWnHYla9uSU66ZzByZwBSCJOEs/pTKVg=
 cloud.google.com/go/pubsub/v2 v2.4.0/go.mod h1:2lS/XQKq5qtOMs6kHBK+WX1ytUC36kLl2ig3zqsGUx8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -106,8 +100,8 @@ go.opentelemetry.io/otel/metric v1.42.0 h1:2jXG+3oZLNXEPfNmnpxKDeZsFI5o4J+nz6xUl
 go.opentelemetry.io/otel/metric v1.42.0/go.mod h1:RlUN/7vTU7Ao/diDkEpQpnz3/92J9ko05BIwxYa2SSI=
 go.opentelemetry.io/otel/sdk v1.42.0 h1:LyC8+jqk6UJwdrI/8VydAq/hvkFKNHZVIWuslJXYsDo=
 go.opentelemetry.io/otel/sdk v1.42.0/go.mod h1:rGHCAxd9DAph0joO4W6OPwxjNTYWghRWmkHuGbayMts=
-go.opentelemetry.io/otel/sdk/metric v1.39.0 h1:cXMVVFVgsIf2YL6QkRF4Urbr/aMInf+2WKg+sEJTtB8=
-go.opentelemetry.io/otel/sdk/metric v1.39.0/go.mod h1:xq9HEVH7qeX69/JnwEfp6fVq5wosJsY1mt4lLfYdVew=
+go.opentelemetry.io/otel/sdk/metric v1.42.0 h1:D/1QR46Clz6ajyZ3G8SgNlTJKBdGp84q9RKCAZ3YGuA=
+go.opentelemetry.io/otel/sdk/metric v1.42.0/go.mod h1:Ua6AAlDKdZ7tdvaQKfSmnFTdHx37+J4ba8MwVCYM5hc=
 go.opentelemetry.io/otel/trace v1.42.0 h1:OUCgIPt+mzOnaUTpOQcBiM/PLQ/Op7oq6g4LenLmOYY=
 go.opentelemetry.io/otel/trace v1.42.0/go.mod h1:f3K9S+IFqnumBkKhRJMeaZeNk9epyhnCmQh/EysQCdc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/gcp/cloudrun_pubsub/main.go
+++ b/gcp/cloudrun_pubsub/main.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"time"
 
-	//nolint:staticcheck // SA1019: pubsub v1 intentionally used until v2 migration
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -33,10 +35,10 @@ func main() {
 		return
 	}
 
-	// Create Pub/Sub client
 	pubsubClient, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		logger.Error("Failed to create Pub/Sub client", "error", err)
+		return
 	}
 	defer func() {
 		if err := pubsubClient.Close(); err != nil {
@@ -44,13 +46,11 @@ func main() {
 		}
 	}()
 
-	// Ensure the topic exists
-	topic := ensureTopicExists(ctx, pubsubClient, topicID, logger)
+	publisher := ensureTopicExists(ctx, pubsubClient, projectID, topicID, logger)
+	defer publisher.Stop()
 
-	// Start the subscriber in a goroutine
-	go subscribeAndLog(ctx, pubsubClient, topicID, logger)
+	go subscribeAndLog(ctx, pubsubClient, projectID, topicID, logger)
 
-	// Set up web server
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB
@@ -59,7 +59,7 @@ func main() {
 				return
 			}
 			message := r.FormValue("message")
-			publishMessage(ctx, topic, message, logger)
+			publishMessage(ctx, publisher, message, logger)
 			if _, err := fmt.Fprintln(w, template); err != nil {
 				logger.Error("Failed to write response", "error", err)
 			}
@@ -84,23 +84,26 @@ func NewLogger() *slog.Logger {
 	return logger
 }
 
-func ensureTopicExists(ctx context.Context, client *pubsub.Client, topicID string, log *slog.Logger) *pubsub.Topic {
-	topic := client.Topic(topicID)
-	exists, err := topic.Exists(ctx)
+func ensureTopicExists(
+	ctx context.Context,
+	client *pubsub.Client,
+	projectID string,
+	topicID string,
+	log *slog.Logger,
+) *pubsub.Publisher {
+	topicName := fmt.Sprintf("projects/%s/topics/%s", projectID, topicID)
+	_, err := client.TopicAdminClient.GetTopic(ctx, &pubsubpb.GetTopicRequest{Topic: topicName})
+	if status.Code(err) == codes.NotFound {
+		_, err = client.TopicAdminClient.CreateTopic(ctx, &pubsubpb.Topic{Name: topicName})
+	}
 	if err != nil {
-		log.Error("Error checking if topic exists", "error", err)
+		log.Error("Failed to ensure topic exists", "error", err)
 	}
-	if !exists {
-		_, err := client.CreateTopic(ctx, topicID)
-		if err != nil {
-			log.Error("Failed to create the topic", "error", err)
-		}
-	}
-	return topic
+	return client.Publisher(topicName)
 }
 
-func publishMessage(ctx context.Context, topic *pubsub.Topic, message string, log *slog.Logger) {
-	result := topic.Publish(ctx, &pubsub.Message{Data: []byte(message)})
+func publishMessage(ctx context.Context, publisher *pubsub.Publisher, message string, log *slog.Logger) {
+	result := publisher.Publish(ctx, &pubsub.Message{Data: []byte(message)})
 	_, err := result.Get(ctx)
 	if err != nil {
 		log.Error("Could not publish message", "error", err)
@@ -108,28 +111,31 @@ func publishMessage(ctx context.Context, topic *pubsub.Topic, message string, lo
 	}
 }
 
-func subscribeAndLog(ctx context.Context, client *pubsub.Client, topicID string, log *slog.Logger) {
+func subscribeAndLog(ctx context.Context, client *pubsub.Client, projectID, topicID string, log *slog.Logger) {
 	subID := topicID + "-sub"
-	sub := client.Subscription(subID)
+	subName := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID)
+	topicName := fmt.Sprintf("projects/%s/topics/%s", projectID, topicID)
 
-	exists, err := sub.Exists(ctx)
-	if err != nil {
-		log.Error("Error checking if subscription exists", "error", err)
-		return
+	_, err := client.SubscriptionAdminClient.GetSubscription(
+		ctx,
+		&pubsubpb.GetSubscriptionRequest{Subscription: subName},
+	)
+	if status.Code(err) == codes.NotFound {
+		_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+			Name:  subName,
+			Topic: topicName,
+		})
 	}
-
-	if !exists {
-		_, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{Topic: client.Topic(topicID)})
-		if err != nil {
-			log.Error("Failed to create the subscription", "error", err)
-			return
-		}
+	if err != nil {
+		log.Error("Failed to ensure subscription exists", "error", err)
+		return
 	}
 
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = sub.Receive(cctx, func(_ context.Context, m *pubsub.Message) {
+	subscriber := client.Subscriber(subName)
+	err = subscriber.Receive(cctx, func(_ context.Context, m *pubsub.Message) {
 		log.Info("Received message", "data", string(m.Data))
 		m.Ack() // Acknowledge that we've consumed the message.
 	})


### PR DESCRIPTION
## Why?

The `cloud.google.com/go/pubsub` v1 client is on a deprecation path; the file
was carrying a `//nolint:staticcheck` for `SA1019` to silence that. Moving to
v2 lets us drop the suppression and align with the supported API surface.

## What?

- Switch the import to `cloud.google.com/go/pubsub/v2`.
- Use `TopicAdminClient` / `SubscriptionAdminClient` for resource management
  (the v2 admin/data plane split), checking existence via grpc `codes.NotFound`
  instead of the v1 `Exists()` helper.
- Use `client.Publisher` / `client.Subscriber` for the data plane and stop the
  publisher on shutdown.
- Drop the staticcheck nolint comment.
- Fix a pre-existing bug where a failed `NewClient` was logged but execution
  continued.

## Notes

`go build`, `go vet`, and `golangci-lint` all clean.